### PR TITLE
Add Single Player Support to Task Board System

### DIFF
--- a/media/lua/client/TaskBoard_Action.lua
+++ b/media/lua/client/TaskBoard_Action.lua
@@ -3,38 +3,12 @@
 
 function onCustomUIKeyPressed(key)
     if key == 22 then
-        print("[Debug] press key 22")
-
         isWindowVisible = not isWindowVisible
         if mainWindow then
             mainWindow:setVisible(isWindowVisible)
-            sendClientCommand(MODDATA_KEY, "ReloadAllTables", {})
+            TaskBoard_Core.reloadAllTables()
         else
             mainWindow = nil
         end
     end
-
-    -- if key == 25 then
-    --     print("[Debug] press key 25")
-    -- end
-
-    -- if key == 26 then
-    --     print("[Debug] press key 26")
-    --     sendClientCommand(MODDATA_KEY, "UpdateTask", task)
-    -- end
-
-    -- if key == 27 then
-    --     print("[Debug] press key 27")
-    --     sendClientCommand(MODDATA_KEY, "DeleteTask", { id = taskID })
-    -- end
-
-    -- if key == 43 then
-    --     print("[Debug] press key 43")
-    --     sendClientCommand(MODDATA_KEY, "RequestAllTasks", {})
-    -- end
-
-    -- if key == 40 then
-    --     print("[Debug] press key 40")
-    --     sendClientCommand(MODDATA_KEY, "DeleteAllTasks", {})
-    -- end
 end

--- a/media/lua/client/TaskBoard_Event.lua
+++ b/media/lua/client/TaskBoard_Event.lua
@@ -20,11 +20,6 @@ kb_DataManager.tasks = {}
 Events.OnReceiveGlobalModData.Add(function(key, data)
     if key ~= MODDATA_KEY then return end
 
-    -- for taskID, task in pairs(data) do
-    --     -- print("  TaskID:", taskID, "Title:", task.title)
-    --     printTable(task)
-    -- end
-
     reloadAllTablesInClient(data)
 end)
 
@@ -71,27 +66,8 @@ end
 Events.OnServerCommand.Add(function(module, command, args)
     if module ~= MODDATA_KEY then return end
  
-    if command == "FetchAllTasks" then
-        kb_DataManager.tasks = args.tasks
-    end
-
     if command == "ReloadAllTables" then
         kb_DataManager.tasks = args.tasks
         reloadAllTablesInClient(kb_DataManager.tasks)
     end
 end)
-
-function printTable(t, indent)
-    indent = indent or 0
-    local prefix = string.rep("  ", indent)
-
-    for key, value in pairs(t) do
-        if type(value) == "table" then
-            print(prefix .. tostring(key) .. " = {")
-            printTable(value, indent + 1)
-            print(prefix .. "}")
-        else
-            print(prefix .. tostring(key) .. " = " .. tostring(value))
-        end
-    end
-end

--- a/media/lua/client/client-ui/ISPanel/TaskCardPanel.lua
+++ b/media/lua/client/client-ui/ISPanel/TaskCardPanel.lua
@@ -63,7 +63,7 @@ function TaskCardPanel:create(task)
     self.richText.text = string.format(
         "%s\n\n%s\n\n\n%s\n\nCreated by:\n%s\n%s\n\nModified by:\n%s\n%s\n",
         task.title,
-        task.description,
+        (task.description ~= "" and task.description or "no description"),
         task.priority,
         formatISODate(task.createdAt),
         task.createdByName,

--- a/media/lua/client/client-ui/ISPanel/TaskFormPanel.lua
+++ b/media/lua/client/client-ui/ISPanel/TaskFormPanel.lua
@@ -133,7 +133,8 @@ function kb_TaskFormPanel.onSubmit()
         createdTask.createdByName = getPlayer(0):getUsername()
         createdTask.lastUserModifiedName = getPlayer(0):getUsername()
 
-        sendClientCommand(MODDATA_KEY, "CreateTask", createdTask)
+        TaskBoard_Core.create(createdTask)
+
     elseif kb_TaskFormPanel.action == "edit" then
         kb_TaskFormPanel.task.title = title
         kb_TaskFormPanel.task.description = description
@@ -141,7 +142,7 @@ function kb_TaskFormPanel.onSubmit()
         kb_TaskFormPanel.task.lastUserModifiedName = getPlayer(0):getUsername()
         kb_TaskFormPanel.task.updatedAt = os.date("!%Y-%m-%dT%H:%M:%SZ")
 
-        sendClientCommand(MODDATA_KEY, "UpdateTask", kb_TaskFormPanel.task)
+        TaskBoard_Core.update(kb_TaskFormPanel.task)
         kb_TaskFormPanel.task = nil  
     end
 

--- a/media/lua/server/TaskBoard_Server.lua
+++ b/media/lua/server/TaskBoard_Server.lua
@@ -1,42 +1,20 @@
--- Server
 MODDATA_KEY = "KB.KanbanBoard"
-
--- function generateUUID()
---     local db = ModData.getOrCreate(MODDATA_KEY)
-
---     local function padWithZeros(num)
---         return string.format("%010d", num) -- Ensures the number is 10 digits long with leading zeros
---     end
-
---     for i = 1, 5 do
---         local id = padWithZeros(ZombRand(0, 1000000000)) -- Generate a number and pad it
---         if not db[id] then return id end
---     end
-
---     return padWithZeros(ZombRand(0, 1000000000)) -- Fallback in case of collision
--- end
 
 Events.OnClientCommand.Add(function(module, command, player, task)
     if module ~= MODDATA_KEY then return end
 
     local db = ModData.getOrCreate(MODDATA_KEY)
-    -- local transmit = function() ModData.transmit(MODDATA_KEY) end
 
     if command == "CreateTask" then
         TaskBoard_Core.create(task)
-        -- task.id = generateUUID()
-        -- db[task.id] = task
-        -- transmit()
-    -- elseif command == "UpdateTask" and db[task.id] then
+
     elseif command == "UpdateTask" then
         TaskBoard_Core.update(task)
-        -- db[task.id] = task
-        -- transmit()
+
     elseif command == "DeleteTask" then
         TaskBoard_Core.delete(task)
-        -- db[task.id] = nil
-        -- transmit()
-    elseif command == "FetchAllTasks" or command == "ReloadAllTables" then
-        sendServerCommand(player, MODDATA_KEY, command, { tasks = db })
+
+    elseif command == "ReloadAllTables" then
+        TaskBoard_Core.reloadAllTables(player)
     end
 end)

--- a/media/lua/server/TaskBoard_Server.lua
+++ b/media/lua/server/TaskBoard_Server.lua
@@ -1,40 +1,41 @@
 -- Server
 MODDATA_KEY = "KB.KanbanBoard"
 
-function generateUUID()
-    local db = ModData.getOrCreate(MODDATA_KEY)
+-- function generateUUID()
+--     local db = ModData.getOrCreate(MODDATA_KEY)
 
-    local function padWithZeros(num)
-        return string.format("%010d", num) -- Ensures the number is 10 digits long with leading zeros
-    end
+--     local function padWithZeros(num)
+--         return string.format("%010d", num) -- Ensures the number is 10 digits long with leading zeros
+--     end
 
-    for i = 1, 5 do
-        local id = padWithZeros(ZombRand(0, 1000000000)) -- Generate a number and pad it
-        if not db[id] then return id end
-    end
+--     for i = 1, 5 do
+--         local id = padWithZeros(ZombRand(0, 1000000000)) -- Generate a number and pad it
+--         if not db[id] then return id end
+--     end
 
-    return padWithZeros(ZombRand(0, 1000000000)) -- Fallback in case of collision
-end
+--     return padWithZeros(ZombRand(0, 1000000000)) -- Fallback in case of collision
+-- end
 
-Events.OnClientCommand.Add(function(module, command, player, args)
+Events.OnClientCommand.Add(function(module, command, player, task)
     if module ~= MODDATA_KEY then return end
 
     local db = ModData.getOrCreate(MODDATA_KEY)
-    local transmit = function() ModData.transmit(MODDATA_KEY) end
+    -- local transmit = function() ModData.transmit(MODDATA_KEY) end
 
     if command == "CreateTask" then
-        args.id = generateUUID()
-        db[args.id] = args
-        transmit()
-    elseif command == "UpdateTask" and db[args.id] then
-        db[args.id] = args
-        transmit()
+        TaskBoard_Core.create(task)
+        -- task.id = generateUUID()
+        -- db[task.id] = task
+        -- transmit()
+    -- elseif command == "UpdateTask" and db[task.id] then
+    elseif command == "UpdateTask" then
+        TaskBoard_Core.update(task)
+        -- db[task.id] = task
+        -- transmit()
     elseif command == "DeleteTask" then
-        db[args.id] = nil
-        transmit()
-    elseif command == "DeleteAllTasks" then
-        table.wipe(db)
-        transmit()
+        TaskBoard_Core.delete(task)
+        -- db[task.id] = nil
+        -- transmit()
     elseif command == "FetchAllTasks" or command == "ReloadAllTables" then
         sendServerCommand(player, MODDATA_KEY, command, { tasks = db })
     end

--- a/media/lua/shared/TaskBoard_Core.lua
+++ b/media/lua/shared/TaskBoard_Core.lua
@@ -1,115 +1,93 @@
--- Persistency Manager
--- Hook under onGameStart then adapt TaskBoard Core
-    MODDATA_KEY = "KB.KanbanBoard"
+MODDATA_KEY = "KB.KanbanBoard"
 
-    TaskBoard_Core = {}
+TaskBoard_Core = {}
 
-    local function handleTaskAction(action, task)
-        local db = ModData.getOrCreate(MODDATA_KEY)
-    
-        if action == "CreateTask" then
-            task.id = generateUUID()
-            db[task.id] = task
-            
-        elseif action == "UpdateTask" and task.id then
-            db[task.id] = task
+local function handleTaskAction(action, task)
+    local db = ModData.getOrCreate(MODDATA_KEY)
 
-        elseif action == "DeleteTask" and task.id then
-            db[task.id] = nil
+    if action == "CreateTask" then
+        task.id = generateUUID()
+        db[task.id] = task
 
-        elseif action == "DeleteAllTasks" then
-            table.wipe(db)
-        
-        elseif action == "FetchAllTasks" then
-            db = task
+    elseif action == "UpdateTask" and task.id then
+        db[task.id] = task
 
-        elseif action == "AssignTasks" then
-            db = task
-        end
-        
+    elseif action == "DeleteTask" and task.id then
+        db[task.id] = nil
+
+    elseif action == "DeleteAllTasks" then
+        table.wipe(db)
+
+    elseif action == "FetchAllTasks" then
         return db
-    end
-    
-    function TaskBoard_Core.fetchAllTasks() 
-        -- server
-        if command == "FetchAllTasks" then
-            kb_DataManager.tasks = args.tasks
-        end
-    
+
+    elseif action == "AssignTasks" then
+        db = task
     end
 
-    function TaskBoard_Core.reloadAll(tasks)
-        if isClient() then
-            sendClientCommand(MODDATA_KEY, "ReloadAllTables", task)
-        elseif isServer() then
-            handleTaskAction("AssignTasks", task)
-            reloadAllTablesInClient(db)
-        else
-            handleTaskAction("AssignTasks", task)
-            reloadAllTablesInClient(ModData.getOrCreate(MODDATA_KEY))
-        end
+    return db
+end
 
-        -- server
-        if command == "ReloadAllTables" then
-            kb_DataManager.tasks = args.tasks
-            reloadAllTablesInClient(kb_DataManager.tasks)
-        end
+function TaskBoard_Core.reloadAllTables(player)
+    if isClient() then
+        sendClientCommand(MODDATA_KEY, "ReloadAllTables", {})
+    elseif isServer() then
+        local db = handleTaskAction("FetchAllTasks")
+        sendServerCommand(player, MODDATA_KEY, "ReloadAllTables", { tasks = db })
+    else
+        reloadAllTablesInClient(ModData.getOrCreate(MODDATA_KEY))
     end
-    
-    function TaskBoard_Core.create(task)
-        print("[TaskBoard_Core.create] Creating task with data:")
-    
-        if isClient() then
-            print("[TaskBoard_Core.create] Detected isClient() - sending ClientCommand")
-            sendClientCommand(MODDATA_KEY, "CreateTask", task)
-        elseif isServer() then
-            print("[TaskBoard_Core.create] Detected isServer() - handling and transmitting ModData")
-            handleTaskAction("CreateTask", task)
-            ModData.transmit(MODDATA_KEY)
-        else
-            print("[TaskBoard_Core.create] Detected singleplayer - handling and reloading tables")
-            handleTaskAction("CreateTask", task)
-            reloadAllTablesInClient(ModData.getOrCreate(MODDATA_KEY))
-        end
-    end
-    
-    function TaskBoard_Core.update(task)
-        if not task.id then return end
+end
 
-        if isClient() then
-            sendClientCommand(MODDATA_KEY, "UpdateTask", task)
-        elseif isServer() then
-            handleTaskAction("UpdateTask", task)
-            ModData.transmit(MODDATA_KEY)
-        else
-            handleTaskAction("UpdateTask", task)
-            reloadAllTablesInClient(ModData.getOrCreate(MODDATA_KEY))
-        end
+function TaskBoard_Core.create(task)
+    if isClient() then
+        sendClientCommand(MODDATA_KEY, "CreateTask", task)
+    elseif isServer() then
+        handleTaskAction("CreateTask", task)
+        ModData.transmit(MODDATA_KEY)
+    else
+        handleTaskAction("CreateTask", task)
+        reloadAllTablesInClient(ModData.getOrCreate(MODDATA_KEY))
+    end
+end
+
+function TaskBoard_Core.update(task)
+    if not task.id then return end
+
+    if isClient() then
+        sendClientCommand(MODDATA_KEY, "UpdateTask", task)
+    elseif isServer() then
+        handleTaskAction("UpdateTask", task)
+        ModData.transmit(MODDATA_KEY)
+    else
+        handleTaskAction("UpdateTask", task)
+        reloadAllTablesInClient(ModData.getOrCreate(MODDATA_KEY))
+    end
+end
+
+function TaskBoard_Core.delete(task)
+    if isClient() then
+        sendClientCommand(MODDATA_KEY, "DeleteTask", task)
+    elseif isServer() then
+        handleTaskAction("DeleteTask", task)
+        ModData.transmit(MODDATA_KEY)
+    else
+        handleTaskAction("DeleteTask", task)
+        reloadAllTablesInClient(ModData.getOrCreate(MODDATA_KEY))
+    end
+end
+
+function generateUUID()
+    local db = ModData.getOrCreate(MODDATA_KEY)
+
+    local function padWithZeros(num)
+        return string.format("%010d", num)
     end
 
-    function TaskBoard_Core.delete(task)
-        if isClient() then
-            sendClientCommand(MODDATA_KEY, "DeleteTask", task)
-        elseif isServer() then
-            handleTaskAction("DeleteTask", task)
-            ModData.transmit(MODDATA_KEY)
-        else
-            handleTaskAction("DeleteTask", task)
-            reloadAllTablesInClient(ModData.getOrCreate(MODDATA_KEY))
-        end
+    for i = 1, 5 do
+        local id = padWithZeros(ZombRand(0, 1000000000))
+        if not db[id] then return id end
     end
-    
-    function generateUUID()
-        local db = ModData.getOrCreate(MODDATA_KEY)
-    
-        local function padWithZeros(num)
-            return string.format("%010d", num) -- Ensures the number is 10 digits long with leading zeros
-        end
-    
-        for i = 1, 5 do
-            local id = padWithZeros(ZombRand(0, 1000000000)) -- Generate a number and pad it
-            if not db[id] then return id end
-        end
-    
-        return padWithZeros(ZombRand(0, 1000000000)) -- Fallback in case of collision
-    end
+
+    return padWithZeros(ZombRand(0, 1000000000))
+end

--- a/media/lua/shared/TaskBoard_Core.lua
+++ b/media/lua/shared/TaskBoard_Core.lua
@@ -1,0 +1,115 @@
+-- Persistency Manager
+-- Hook under onGameStart then adapt TaskBoard Core
+    MODDATA_KEY = "KB.KanbanBoard"
+
+    TaskBoard_Core = {}
+
+    local function handleTaskAction(action, task)
+        local db = ModData.getOrCreate(MODDATA_KEY)
+    
+        if action == "CreateTask" then
+            task.id = generateUUID()
+            db[task.id] = task
+            
+        elseif action == "UpdateTask" and task.id then
+            db[task.id] = task
+
+        elseif action == "DeleteTask" and task.id then
+            db[task.id] = nil
+
+        elseif action == "DeleteAllTasks" then
+            table.wipe(db)
+        
+        elseif action == "FetchAllTasks" then
+            db = task
+
+        elseif action == "AssignTasks" then
+            db = task
+        end
+        
+        return db
+    end
+    
+    function TaskBoard_Core.fetchAllTasks() 
+        -- server
+        if command == "FetchAllTasks" then
+            kb_DataManager.tasks = args.tasks
+        end
+    
+    end
+
+    function TaskBoard_Core.reloadAll(tasks)
+        if isClient() then
+            sendClientCommand(MODDATA_KEY, "ReloadAllTables", task)
+        elseif isServer() then
+            handleTaskAction("AssignTasks", task)
+            reloadAllTablesInClient(db)
+        else
+            handleTaskAction("AssignTasks", task)
+            reloadAllTablesInClient(ModData.getOrCreate(MODDATA_KEY))
+        end
+
+        -- server
+        if command == "ReloadAllTables" then
+            kb_DataManager.tasks = args.tasks
+            reloadAllTablesInClient(kb_DataManager.tasks)
+        end
+    end
+    
+    function TaskBoard_Core.create(task)
+        print("[TaskBoard_Core.create] Creating task with data:")
+    
+        if isClient() then
+            print("[TaskBoard_Core.create] Detected isClient() - sending ClientCommand")
+            sendClientCommand(MODDATA_KEY, "CreateTask", task)
+        elseif isServer() then
+            print("[TaskBoard_Core.create] Detected isServer() - handling and transmitting ModData")
+            handleTaskAction("CreateTask", task)
+            ModData.transmit(MODDATA_KEY)
+        else
+            print("[TaskBoard_Core.create] Detected singleplayer - handling and reloading tables")
+            handleTaskAction("CreateTask", task)
+            reloadAllTablesInClient(ModData.getOrCreate(MODDATA_KEY))
+        end
+    end
+    
+    function TaskBoard_Core.update(task)
+        if not task.id then return end
+
+        if isClient() then
+            sendClientCommand(MODDATA_KEY, "UpdateTask", task)
+        elseif isServer() then
+            handleTaskAction("UpdateTask", task)
+            ModData.transmit(MODDATA_KEY)
+        else
+            handleTaskAction("UpdateTask", task)
+            reloadAllTablesInClient(ModData.getOrCreate(MODDATA_KEY))
+        end
+    end
+
+    function TaskBoard_Core.delete(task)
+        if isClient() then
+            sendClientCommand(MODDATA_KEY, "DeleteTask", task)
+        elseif isServer() then
+            handleTaskAction("DeleteTask", task)
+            ModData.transmit(MODDATA_KEY)
+        else
+            handleTaskAction("DeleteTask", task)
+            reloadAllTablesInClient(ModData.getOrCreate(MODDATA_KEY))
+        end
+    end
+    
+    function generateUUID()
+        local db = ModData.getOrCreate(MODDATA_KEY)
+    
+        local function padWithZeros(num)
+            return string.format("%010d", num) -- Ensures the number is 10 digits long with leading zeros
+        end
+    
+        for i = 1, 5 do
+            local id = padWithZeros(ZombRand(0, 1000000000)) -- Generate a number and pad it
+            if not db[id] then return id end
+        end
+    
+        return padWithZeros(ZombRand(0, 1000000000)) -- Fallback in case of collision
+    end


### PR DESCRIPTION
Resolve Issues: #15 , #2 

Supports Single Player mode via ```TaskBoard_Core```. This new file handles both Client and Server requests that adhere to the Single Responsibility Principle. All logic will be handled by the ```TaskBoard_Core```.

This file has a global property named ```TaskBoard_Core```, the moddata key and uuid generator also transferred here. 