### PR TITLE
Allow a furniture to be assigned as a Task Board

### DIFF
--- a/media/lua/client/TaskBoard_Action.lua
+++ b/media/lua/client/TaskBoard_Action.lua
@@ -1,14 +1,14 @@
--- Keyboard Reference: 
+-- Keyboard Reference:
 -- https://theindiestone.com/forums/index.php?/topic/9799-key-code-reference/
 
-function onCustomUIKeyPressed(key)
-    if key == 22 then
-        isWindowVisible = not isWindowVisible
-        if mainWindow then
-            mainWindow:setVisible(isWindowVisible)
-            TaskBoard_Core.reloadAllTables()
-        else
-            mainWindow = nil
-        end
-    end
-end
+-- function onCustomUIKeyPressed(key)
+--     if key == 22 then
+--         isWindowVisible = not isWindowVisible
+--         if mainWindow then
+--             mainWindow:setVisible(isWindowVisible)
+--             TaskBoard_Core.reloadAllTables()
+--         else
+--             mainWindow = nil
+--         end
+--     end
+-- end

--- a/media/lua/client/TaskBoard_ContextMenu.lua
+++ b/media/lua/client/TaskBoard_ContextMenu.lua
@@ -84,6 +84,14 @@ local function onRemoveTaskBoard(worldobjects, square, furniture)
     modal:addToUIManager()
 end
 
+local function onOpenTaskBoard(furniture)
+    if not furniture then return end
+
+    TaskBoard_Core.reloadAllTables(getPlayer(), furniture)
+
+    mainWindow:setVisible(true)
+end
+
 local function onFillWorldObjectContextMenu(player, context, worldobjects, test)
     local square = getPlayer():getCurrentSquare()
     local processedObjects = {}
@@ -99,6 +107,7 @@ local function onFillWorldObjectContextMenu(player, context, worldobjects, test)
                 context:addOption("Make Task Board (" .. currentName .. ")", worldobjects, onMakeTaskBoard, square, object)
             end
             if modData.isTaskBoard then
+                context:addOption("Open Task Board (" .. currentName .. ")", object, onOpenTaskBoard, object)
                 context:addOption("Remove Task Board (" .. currentName .. ")", worldobjects, onRemoveTaskBoard, square, object)
             end
         end

--- a/media/lua/client/TaskBoard_ContextMenu.lua
+++ b/media/lua/client/TaskBoard_ContextMenu.lua
@@ -1,5 +1,6 @@
 local allowedTaskBoardFurnitures = {
     "location_business_office_generic_01_7",
+    "location_business_office_generic_01_15",
 }
 
 local function isFurnitureWhitelisted(furniture)
@@ -84,11 +85,12 @@ local function onRemoveTaskBoard(worldobjects, square, furniture)
 end
 
 local function onFillWorldObjectContextMenu(player, context, worldobjects, test)
-    local square = getPlayer():getCurrentSquare()
     for _, object in ipairs(worldobjects) do
         if object and instanceof(object, "IsoObject") then
             local modData = object:getModData()
             local currentName = getFurnitureName(object)
+            local square = object:getSquare()
+
             -- Designed to be flexible. Feature will not break if the whitelist changes.
             if isFurnitureWhitelisted(object) and not modData.isTaskBoard then
                 context:addOption("Make Task Board (" .. currentName .. ")", worldobjects, onMakeTaskBoard, square, object)

--- a/media/lua/client/TaskBoard_ContextMenu.lua
+++ b/media/lua/client/TaskBoard_ContextMenu.lua
@@ -1,0 +1,103 @@
+local allowedTaskBoardFurnitures = {
+    "location_business_office_generic_01_7",
+}
+
+local function isFurnitureWhitelisted(furniture)
+    if not furniture then return false end
+
+    local sprite = furniture:getSprite()
+    if sprite then
+        local spriteName = sprite:getName()
+        for _, allowedSpriteName in ipairs(allowedTaskBoardFurnitures) do
+            if spriteName == allowedSpriteName then
+                return true
+            end
+        end
+    end
+
+    return false
+end
+
+local function getFurnitureName(furniture)
+    if not furniture then return "Unknown Furniture" end
+
+    local sprite = furniture:getSprite()
+    if sprite then
+        local translationKey = sprite:getProperties():Val("CustomName")
+        if translationKey then
+            local translatedName = getText(translationKey)
+            if translatedName and translatedName ~= "" then
+                return translatedName
+            end
+        end
+
+        return sprite:getName()
+    end
+
+    return "Unknown Furniture"
+end
+
+local function onMakeTaskBoard(worldobjects, square, furniture)
+    if not furniture then return end
+
+    local modData = furniture:getModData()
+    modData.isTaskBoard = true
+    -- more data here to create.
+    furniture:transmitModData()
+
+    getPlayer():Say("I created a task board here.")
+end
+
+local function onConfirmRemoveTaskBoard(worldobjects, square, furniture)
+    if not furniture then return end
+
+    local modData = furniture:getModData()
+    modData.isTaskBoard = nil
+    -- more data here to remove.
+    furniture:transmitModData()
+
+    getPlayer():Say("I removed the task board here.")
+end
+
+local function onRemoveTaskBoard(worldobjects, square, furniture)
+    if not furniture then return end
+
+    local player = getPlayer()
+    local screenWidth = getCore():getScreenWidth()
+    local screenHeight = getCore():getScreenHeight()
+    local dialogWidth = 200
+    local dialogHeight = 100
+    local dialogX = (screenWidth - dialogWidth) / 2
+    local dialogY = (screenHeight - dialogHeight) / 2
+    local modal = ISModalDialog:new(
+        dialogX, dialogY, dialogWidth, dialogHeight,
+        "Are you sure? All tasks will be lost once confirmed.",
+        true, nil,
+        function(dialog, button)
+            if button.internal == "YES" then
+                onConfirmRemoveTaskBoard(worldobjects, square, furniture)
+            end
+        end
+    )
+    modal:initialise()
+    modal:addToUIManager()
+end
+
+local function onFillWorldObjectContextMenu(player, context, worldobjects, test)
+    local square = getPlayer():getCurrentSquare()
+    for _, object in ipairs(worldobjects) do
+        if object and instanceof(object, "IsoObject") then
+            local modData = object:getModData()
+            local currentName = getFurnitureName(object)
+            -- Designed to be flexible. Feature will not break if the whitelist changes.
+            if isFurnitureWhitelisted(object) and not modData.isTaskBoard then
+                context:addOption("Make Task Board (" .. currentName .. ")", worldobjects, onMakeTaskBoard, square, object)
+            end
+            if modData.isTaskBoard then
+                context:addOption("Remove Task Board (" .. currentName .. ")", worldobjects, onRemoveTaskBoard, square, object)
+            end
+        end
+    end
+end
+
+Events.OnFillWorldObjectContextMenu.Add(onFillWorldObjectContextMenu)

--- a/media/lua/client/TaskBoard_ContextMenu.lua
+++ b/media/lua/client/TaskBoard_ContextMenu.lua
@@ -85,8 +85,11 @@ local function onRemoveTaskBoard(worldobjects, square, furniture)
 end
 
 local function onFillWorldObjectContextMenu(player, context, worldobjects, test)
+    local square = getPlayer():getCurrentSquare()
+    local processedObjects = {}
     for _, object in ipairs(worldobjects) do
-        if object and instanceof(object, "IsoObject") then
+        if object and instanceof(object, "IsoObject") and not processedObjects[object] then
+            processedObjects[object] = true
             local modData = object:getModData()
             local currentName = getFurnitureName(object)
             local square = object:getSquare()

--- a/media/lua/client/TaskBoard_Event.lua
+++ b/media/lua/client/TaskBoard_Event.lua
@@ -8,7 +8,7 @@ require 'TaskBoard_Action'
 -- Event
 --Events.OnGameStart.Add(main)
 Events.OnGameStart.Add(main)
-Events.OnCustomUIKeyPressed.Add(onCustomUIKeyPressed)
+-- Events.OnCustomUIKeyPressed.Add(onCustomUIKeyPressed)
 
 MODDATA_KEY = "KB.KanbanBoard"
 
@@ -17,13 +17,17 @@ kb_DataManager = {}
 kb_DataManager.tasks = {}
 
 -- for Create, Edit and Delete event on the server
-Events.OnReceiveGlobalModData.Add(function(key, data)
-    if key ~= MODDATA_KEY then return end
+-- Events.OnReceiveGlobalModData.Add(function(key, data)
+--     if key ~= MODDATA_KEY then return end
 
-    reloadAllTablesInClient(data)
-end)
+--     reloadAllTablesInClient(data)
+-- end)
 
-function reloadAllTablesInClient(tasks)
+function reloadAllTablesInClient(furniture)
+    if not furniture then return end
+
+    local tasks = furniture:getModData().tasks or {}
+
     kb_leftListBox:clear()
     kb_middleListBox:clear()
     kb_rightListBox:clear()
@@ -63,11 +67,11 @@ function reloadAllTablesInClient(tasks)
     end
 end
 
-Events.OnServerCommand.Add(function(module, command, args)
-    if module ~= MODDATA_KEY then return end
- 
-    if command == "ReloadAllTables" then
-        kb_DataManager.tasks = args.tasks
-        reloadAllTablesInClient(kb_DataManager.tasks)
-    end
-end)
+-- Events.OnServerCommand.Add(function(module, command, args)
+--     if module ~= MODDATA_KEY then return end
+
+--     if command == "ReloadAllTables" then
+--         kb_DataManager.tasks = args.tasks
+--         reloadAllTablesInClient(kb_DataManager.tasks)
+--     end
+-- end)

--- a/media/lua/client/TaskBoard_Main.lua
+++ b/media/lua/client/TaskBoard_Main.lua
@@ -7,7 +7,7 @@
 -- All functions acts as fileprivate since the file must be require first to other lua files.
 -- All properties were declare local or private except the 3 table reference.
 
--- Debug: 
+-- Debug:
 -- panel.backgroundColor = {r=0, g=0, b=1, a=1}
 
 -- Global Properties:
@@ -22,9 +22,11 @@ local ISPlusIcon = require('client-ui/ISPanel/ISPlusIcon')
 local ISPlusIconDebug = require('client-ui/ISPanel/ISPlusIconDebug')
 
 mainWindow = {}
+mainWindowID = nil
 
 function main()
     drawKanbanBoard()
+    mainWindowID = -1
 end
 
 function drawKanbanBoard()
@@ -40,7 +42,7 @@ function drawAllSections(mainWindow)
     drawRightSection(mainWindow, middleSection)
 end
 
-function drawMainWindow() 
+function drawMainWindow()
     local mainWindow = MISCollapsableWindow:new(0, 0, getCore():getScreenWidth() * 0.5, getCore():getScreenHeight() * 0.6)
     mainWindow:setX((getCore():getScreenWidth() * 0.5) - (mainWindow:getWidth() * 0.5))
     mainWindow:setY((getCore():getScreenHeight() * 0.5) - (mainWindow:getHeight() * 0.5) - 25)
@@ -52,7 +54,7 @@ function drawMainWindow()
     return mainWindow
 end
 
-function drawSectionHeaderPanel(mainWindow) 
+function drawSectionHeaderPanel(mainWindow)
     local sectionHeaderPanel = ISPanel:new(0, mainWindow:titleBarHeight(), mainWindow.width, mainWindow:titleBarHeight() * 2)
     sectionHeaderPanel:initialise()
     sectionHeaderPanel.backgroundColor = {r=0, g=0, b=0, a=1}
@@ -60,7 +62,7 @@ function drawSectionHeaderPanel(mainWindow)
 
     local leftHeaderSection = drawLeftHeaderSection(mainWindow)
     drawPlusIcon(leftHeaderSection)
-    
+
 
     local middleHeaderSection = drawMiddleHeaderSection(mainWindow, leftHeaderSection)
     -- drawPlusIconDebug(middleHeaderSection)
@@ -76,23 +78,23 @@ function drawLeftHeaderSection(mainWindow)
     sectionLeftHeaderPanel:setTitle("To Do")
 
     mainWindow:addChild(sectionLeftHeaderPanel)
-    
+
     return sectionLeftHeaderPanel
 end
 
-function drawPlusIcon(sectionLeftHeaderPanel) 
+function drawPlusIcon(sectionLeftHeaderPanel)
     local plusPanel = ISPlusIcon:new(0, 0, sectionLeftHeaderPanel:getHeight(), sectionLeftHeaderPanel:getHeight())
     plusPanel:initialise();
     sectionLeftHeaderPanel:addChild(plusPanel)
 end
 
-function drawPlusIconDebug(middleHeaderSection) 
+function drawPlusIconDebug(middleHeaderSection)
     local plusPanelDebug = ISPlusIconDebug:new(0, 0, middleHeaderSection:getHeight(), middleHeaderSection:getHeight())
     plusPanelDebug:initialise();
     middleHeaderSection:addChild(plusPanelDebug)
 end
 
-function drawMiddleHeaderSection(mainWindow, leftHeaderSection) 
+function drawMiddleHeaderSection(mainWindow, leftHeaderSection)
     local sectionMiddleHeaderPanel = MISPanel:new(leftHeaderSection:getWidth(), mainWindow:titleBarHeight(), mainWindow.width / 3, mainWindow:titleBarHeight() * 2)
     sectionMiddleHeaderPanel:initialise()
     sectionMiddleHeaderPanel:setTitle("In Progress")
@@ -101,7 +103,7 @@ function drawMiddleHeaderSection(mainWindow, leftHeaderSection)
     return sectionMiddleHeaderPanel
 end
 
-function drawRightHeaderSection(mainWindow, middleHeaderSection) 
+function drawRightHeaderSection(mainWindow, middleHeaderSection)
     local sectionRightHeaderPanel = MISPanel:new(middleHeaderSection:getWidth() * 2, mainWindow:titleBarHeight(), mainWindow.width / 3, mainWindow:titleBarHeight() * 2)
     sectionRightHeaderPanel:initialise()
     sectionRightHeaderPanel:setTitle("Done")
@@ -117,7 +119,7 @@ function drawLeftSection(mainWindow, sectionHeaderPanel)
 
     childLeftPanel:addChild(kb_leftListBox)
     mainWindow:addChild(childLeftPanel)
-    
+
     return childLeftPanel
 end
 

--- a/media/lua/client/client-ui/ISPanel/TaskFormPanel.lua
+++ b/media/lua/client/client-ui/ISPanel/TaskFormPanel.lua
@@ -141,7 +141,7 @@ function kb_TaskFormPanel.onSubmit()
         createdTask.createdByCharacterName = TaskBoard_Utils.getCharacterName(player)
         createdTask.lastUserModifiedCharacterName = createdTask.createdByCharacterName
 
-        TaskBoard_Core.create(createdTask)
+        TaskBoard_Core.create(mainWindowID, createdTask)
 
     elseif kb_TaskFormPanel.action == "edit" then
         kb_TaskFormPanel.task.title = title
@@ -155,7 +155,7 @@ function kb_TaskFormPanel.onSubmit()
         kb_TaskFormPanel.task.updatedAtGame = TaskBoard_Utils.getCurrentGameTime()
         kb_TaskFormPanel.task.datesSetInRealTime = not SandboxVars.TaskBoard.UseInGameTime -- this is for due dates, state dates and the like.
 
-        TaskBoard_Core.update(kb_TaskFormPanel.task)
+        TaskBoard_Core.update(mainWindowID, kb_TaskFormPanel.task)
         kb_TaskFormPanel.task = nil
     end
 

--- a/media/lua/client/client-ui/ISScrollingListBox/MISScrollingListBox.lua
+++ b/media/lua/client/client-ui/ISScrollingListBox/MISScrollingListBox.lua
@@ -80,7 +80,7 @@ function MISScrollingListBox:onMoveTask(task, targetSection)
     newTask.updatedAt = TaskBoard_Utils.getCurrentRealTime()
     newTask.updatedAtGame = TaskBoard_Utils.getCurrentGameTime()
 
-    sendClientCommand(MODDATA_KEY, "UpdateTask", task)
+    TaskBoard_Core.update(mainWindowID, newTask)
 end
 
 function formatISODateForCard(isoString)

--- a/media/lua/server/TaskBoard_Server.lua
+++ b/media/lua/server/TaskBoard_Server.lua
@@ -1,20 +1,20 @@
-MODDATA_KEY = "KB.KanbanBoard"
+-- MODDATA_KEY = "KB.KanbanBoard"
 
-Events.OnClientCommand.Add(function(module, command, player, task)
-    if module ~= MODDATA_KEY then return end
+-- Events.OnClientCommand.Add(function(module, command, player, task)
+--     if module ~= MODDATA_KEY then return end
 
-    local db = ModData.getOrCreate(MODDATA_KEY)
+--     local db = ModData.getOrCreate(MODDATA_KEY)
 
-    if command == "CreateTask" then
-        TaskBoard_Core.create(task)
+--     if command == "CreateTask" then
+--         TaskBoard_Core.create(task)
 
-    elseif command == "UpdateTask" then
-        TaskBoard_Core.update(task)
+--     elseif command == "UpdateTask" then
+--         TaskBoard_Core.update(task)
 
-    elseif command == "DeleteTask" then
-        TaskBoard_Core.delete(task)
+--     elseif command == "DeleteTask" then
+--         TaskBoard_Core.delete(task)
 
-    elseif command == "ReloadAllTables" then
-        TaskBoard_Core.reloadAllTables(player)
-    end
-end)
+--     elseif command == "ReloadAllTables" then
+--         TaskBoard_Core.reloadAllTables(player)
+--     end
+-- end)

--- a/media/lua/shared/TaskBoard_Core.lua
+++ b/media/lua/shared/TaskBoard_Core.lua
@@ -1,93 +1,209 @@
-MODDATA_KEY = "KB.KanbanBoard"
-
 TaskBoard_Core = {}
 
-local function generateUUID()
-    local db = ModData.getOrCreate(MODDATA_KEY)
+-- Generate a unique ID for tasks
+local function generateUUID(furniture)
+    local modData = furniture:getModData()
+    modData.tasks = modData.tasks or {}
 
     local function padWithZeros(num)
         return string.format("%010d", num)
     end
 
-    for i = 1, 5 do
+    for i = 1, 1000 do
         local id = padWithZeros(ZombRand(0, 1000000000))
-        if not db[id] then return id end
+        if not modData.tasks[id] then return id end
     end
 
-    error("Failed to generate a unique ID after 5 attempts.")
+    error("Failed to generate a unique ID after 1000 attempts.")
 end
 
-local function handleTaskAction(action, task)
-    local db = ModData.getOrCreate(MODDATA_KEY)
+-- Handle task actions for a specific furniture
+local function handleTaskAction(furniture, action, task)
+    local modData = furniture:getModData()
+    modData.tasks = modData.tasks or {}
 
     if action == "CreateTask" then
-        task.id = generateUUID()
-        db[task.id] = task
+        task.id = generateUUID(furniture)
+        modData.tasks[task.id] = task
 
     elseif action == "UpdateTask" and task.id then
-        db[task.id] = task
+        modData.tasks[task.id] = task
 
     elseif action == "DeleteTask" and task.id then
-        db[task.id] = nil
+        modData.tasks[task.id] = nil
 
     elseif action == "DeleteAllTasks" then
-        table.wipe(db)
+        modData.tasks = {}
 
     elseif action == "FetchAllTasks" then
-        return db
-
-    elseif action == "AssignTasks" then
-        db = task
+        return modData.tasks
     end
 
-    return db
+    -- Sync modData in multiplayer
+    furniture:transmitModData()
+    return modData.tasks
 end
 
-function TaskBoard_Core.reloadAllTables(player)
-    if isClient() then
-        sendClientCommand(MODDATA_KEY, "ReloadAllTables", {})
-    elseif isServer() then
-        local db = handleTaskAction("FetchAllTasks")
-        sendServerCommand(player, MODDATA_KEY, "ReloadAllTables", { tasks = db })
-    else
-        reloadAllTablesInClient(ModData.getOrCreate(MODDATA_KEY))
-    end
+-- Reload all tasks for a specific furniture
+function TaskBoard_Core.reloadAllTables(player, furniture)
+    if not furniture then return end
+
+    -- local modData = furniture:getModData()
+    -- modData.tasks = modData.tasks or {}
+
+    -- if isClient() then
+    --     sendClientCommand("TaskBoard", "ReloadAllTables", { tasks = modData.tasks })
+    -- elseif isServer() then
+    --     sendServerCommand(player, "TaskBoard", "ReloadAllTables", { tasks = modData.tasks })
+    -- else
+    --     reloadAllTablesInClient(modData.tasks)
+    -- end
+
+    mainWindowID = furniture
+    reloadAllTablesInClient(furniture)
 end
 
-function TaskBoard_Core.create(task)
-    if isClient() then
-        sendClientCommand(MODDATA_KEY, "CreateTask", task)
-    elseif isServer() then
-        handleTaskAction("CreateTask", task)
-        ModData.transmit(MODDATA_KEY)
-    else
-        handleTaskAction("CreateTask", task)
-        reloadAllTablesInClient(ModData.getOrCreate(MODDATA_KEY))
-    end
+-- Create a new task for a specific furniture
+function TaskBoard_Core.create(furniture, task)
+    if not furniture then return end
+
+    -- if isClient() then
+    --     sendClientCommand("TaskBoard", "CreateTask", { furniture = furniture, task = task })
+    -- elseif isServer() then
+    --     handleTaskAction(furniture, "CreateTask", task)
+    -- else
+    --     handleTaskAction(furniture, "CreateTask", task)
+    --     reloadAllTablesInClient(furniture:getModData().tasks)
+    -- end
+
+    handleTaskAction(furniture, "CreateTask", task)
+    reloadAllTablesInClient(furniture)
 end
 
-function TaskBoard_Core.update(task)
-    if not task.id then return end
+-- Update an existing task for a specific furniture
+function TaskBoard_Core.update(furniture, task)
+    if not furniture or not task.id then return end
 
-    if isClient() then
-        sendClientCommand(MODDATA_KEY, "UpdateTask", task)
-    elseif isServer() then
-        handleTaskAction("UpdateTask", task)
-        ModData.transmit(MODDATA_KEY)
-    else
-        handleTaskAction("UpdateTask", task)
-        reloadAllTablesInClient(ModData.getOrCreate(MODDATA_KEY))
-    end
+    -- if isClient() then
+    --     sendClientCommand("TaskBoard", "UpdateTask", { furniture = furniture, task = task })
+    -- elseif isServer() then
+    --     handleTaskAction(furniture, "UpdateTask", task)
+    -- else
+    --     handleTaskAction(furniture, "UpdateTask", task)
+    --     reloadAllTablesInClient(furniture:getModData().tasks)
+    -- end
+
+    handleTaskAction(furniture, "UpdateTask", task)
+    reloadAllTablesInClient(furniture)
 end
 
-function TaskBoard_Core.delete(task)
-    if isClient() then
-        sendClientCommand(MODDATA_KEY, "DeleteTask", task)
-    elseif isServer() then
-        handleTaskAction("DeleteTask", task)
-        ModData.transmit(MODDATA_KEY)
-    else
-        handleTaskAction("DeleteTask", task)
-        reloadAllTablesInClient(ModData.getOrCreate(MODDATA_KEY))
-    end
+-- Delete a task for a specific furniture
+function TaskBoard_Core.delete(furniture, task)
+    if not furniture or not task.id then return end
+
+    -- if isClient() then
+    --     sendClientCommand("TaskBoard", "DeleteTask", { furniture = furniture, task = task })
+    -- elseif isServer() then
+    --     handleTaskAction(furniture, "DeleteTask", task)
+    -- else
+    --     handleTaskAction(furniture, "DeleteTask", task)
+    --     reloadAllTablesInClient(furniture:getModData().tasks)
+    -- end
+
+    handleTaskAction(furniture, "DeleteTask", task)
+    reloadAllTablesInClient(furniture)
 end
+
+-- MODDATA_KEY = "KB.KanbanBoard"
+
+-- TaskBoard_Core = {}
+
+-- local function generateUUID()
+--     local db = ModData.getOrCreate(MODDATA_KEY)
+
+--     local function padWithZeros(num)
+--         return string.format("%010d", num)
+--     end
+
+--     for i = 1, 5 do
+--         local id = padWithZeros(ZombRand(0, 1000000000))
+--         if not db[id] then return id end
+--     end
+
+--     error("Failed to generate a unique ID after 5 attempts.")
+-- end
+
+-- local function handleTaskAction(action, task)
+--     local db = ModData.getOrCreate(MODDATA_KEY)
+
+--     if action == "CreateTask" then
+--         task.id = generateUUID()
+--         db[task.id] = task
+
+--     elseif action == "UpdateTask" and task.id then
+--         db[task.id] = task
+
+--     elseif action == "DeleteTask" and task.id then
+--         db[task.id] = nil
+
+--     elseif action == "DeleteAllTasks" then
+--         table.wipe(db)
+
+--     elseif action == "FetchAllTasks" then
+--         return db
+
+--     elseif action == "AssignTasks" then
+--         db = task
+--     end
+
+--     return db
+-- end
+
+-- function TaskBoard_Core.reloadAllTables(player)
+--     if isClient() then
+--         sendClientCommand(MODDATA_KEY, "ReloadAllTables", {})
+--     elseif isServer() then
+--         local db = handleTaskAction("FetchAllTasks")
+--         sendServerCommand(player, MODDATA_KEY, "ReloadAllTables", { tasks = db })
+--     else
+--         reloadAllTablesInClient(ModData.getOrCreate(MODDATA_KEY))
+--     end
+-- end
+
+-- function TaskBoard_Core.create(task)
+--     if isClient() then
+--         sendClientCommand(MODDATA_KEY, "CreateTask", task)
+--     elseif isServer() then
+--         handleTaskAction("CreateTask", task)
+--         ModData.transmit(MODDATA_KEY)
+--     else
+--         handleTaskAction("CreateTask", task)
+--         reloadAllTablesInClient(ModData.getOrCreate(MODDATA_KEY))
+--     end
+-- end
+
+-- function TaskBoard_Core.update(task)
+--     if not task.id then return end
+
+--     if isClient() then
+--         sendClientCommand(MODDATA_KEY, "UpdateTask", task)
+--     elseif isServer() then
+--         handleTaskAction("UpdateTask", task)
+--         ModData.transmit(MODDATA_KEY)
+--     else
+--         handleTaskAction("UpdateTask", task)
+--         reloadAllTablesInClient(ModData.getOrCreate(MODDATA_KEY))
+--     end
+-- end
+
+-- function TaskBoard_Core.delete(task)
+--     if isClient() then
+--         sendClientCommand(MODDATA_KEY, "DeleteTask", task)
+--     elseif isServer() then
+--         handleTaskAction("DeleteTask", task)
+--         ModData.transmit(MODDATA_KEY)
+--     else
+--         handleTaskAction("DeleteTask", task)
+--         reloadAllTablesInClient(ModData.getOrCreate(MODDATA_KEY))
+--     end
+-- end

--- a/media/lua/shared/TaskBoard_Core.lua
+++ b/media/lua/shared/TaskBoard_Core.lua
@@ -14,7 +14,7 @@ local function generateUUID()
         if not db[id] then return id end
     end
 
-    return padWithZeros(ZombRand(0, 1000000000))
+    error("Failed to generate a unique ID after 5 attempts.")
 end
 
 local function handleTaskAction(action, task)


### PR DESCRIPTION
# Details

***~~Core functionality is still there where you press `U` to bring up the Task Board!~~*** It is now dormant, but still exists.

This pull request will slowly introduce the Task Board living inside a furniture assigned as a Task Board.

Closes #11 as it makes the issue obsolete.

# What it has now

- [x] Assign a furniture as a Task Board through a context menu.
- [x] Remove task board from a furniture through context menu.
- [x] Implement a static whitelist for allowable furnitures to be used as a task board.
- [x] Store the tasks in the furniture.
- [ ] Press E to interact with taskboard.
- [ ] Clean the code and restructure the Core module.
- [ ] Migration from global mod data to furniture mod data in existing saves.