### PR TITLE
Task Board Title

### DIFF
--- a/media/lua/client/TaskBoard_ContextMenu.lua
+++ b/media/lua/client/TaskBoard_ContextMenu.lua
@@ -8,6 +8,7 @@ local function onMakeTaskBoard(worldobjects, square, furniture)
     local modData = TaskBoard_Core.fetchModData(furniture)
     modData.isTaskBoard = true
     modData.tasks = {}
+    modData.boardTitle = TaskBoard_Utils.getFurnitureName(furniture) .. " Task Board"
     -- more data here to create.
 
     furniture:transmitModData()

--- a/media/lua/client/TaskBoard_ForceCloseBoard.lua
+++ b/media/lua/client/TaskBoard_ForceCloseBoard.lua
@@ -1,0 +1,13 @@
+local function closeTaskBoardWindow()
+    if not isServer() then
+        local player = getPlayer()
+        if not player or not TaskBoard_mainWindowFurniture then return end
+        local square = TaskBoard_mainWindowFurniture:getSquare()
+
+        if not TaskBoard_Utils.isWithinRange(player, square, 1) then
+            TaskBoard_Utils.closeTaskBoardMainWindow()
+        end
+    end
+end
+
+Events.OnTick.Add(closeTaskBoardWindow)

--- a/media/lua/client/TaskBoard_Main.lua
+++ b/media/lua/client/TaskBoard_Main.lua
@@ -88,6 +88,8 @@ local function drawMainWindow()
     window:addToUIManager()
     window:setVisible(false)
 
+    TaskBoard_Title.patchWindowForRename(window)
+
     return window
 end
 
@@ -158,7 +160,6 @@ local function closeTaskBoardWindow()
 end
 
 Events.OnGameStart.Add(main)
-Events.OnTick.Add(closeTaskBoardWindow)
 
 function TaskBoard_Debug_InitializeMainWindow()
     if TaskBoard_mainWindow then

--- a/media/lua/client/TaskBoard_Main.lua
+++ b/media/lua/client/TaskBoard_Main.lua
@@ -159,3 +159,12 @@ end
 
 Events.OnGameStart.Add(main)
 Events.OnTick.Add(closeTaskBoardWindow)
+
+function TaskBoard_Debug_InitializeMainWindow()
+    if TaskBoard_mainWindow then
+        TaskBoard_mainWindow:setVisible(false)
+    end
+    TaskBoard_mainWindow = nil
+    main()
+    print("Re-initialized TaskBoard Main Window.")
+end

--- a/media/lua/client/TaskBoard_SynchronizeTable.lua
+++ b/media/lua/client/TaskBoard_SynchronizeTable.lua
@@ -13,7 +13,14 @@ local commandHandlers = {
         if TaskBoard_mainWindowFurniture == taskBoard then
             TaskBoard_Utils.closeTaskBoardMainWindow()
         end
-    end
+    end,
+
+    TaskBoardTitleUpdated = function(args, taskBoard)
+        TaskBoard_Title.set(taskBoard, args.title)
+        if TaskBoard_mainWindowFurniture == taskBoard then
+            TaskBoard_Core.reloadAllTables(getPlayer(), taskBoard)
+        end
+    end,
 }
 
 local function onServerCommand(module, command, args)

--- a/media/lua/client/TaskBoard_Title.lua
+++ b/media/lua/client/TaskBoard_Title.lua
@@ -1,61 +1,82 @@
+require("ISUI/ISPanel")
+require("ISUI/ISButton")
+require("ISUI/ISTextBox")
+
 TaskBoard_Title = {}
 
 local function showRenameDialog(window)
-    local textBox = ISTextBox:new(
-        getCore():getScreenWidth() / 2 - 150,
-        getCore():getScreenHeight() / 2 - 50,
-        300, 100,
-        "Rename Board",
-        window:getTitle(),
-        nil,
-        function(button, newTitle)
-            if button and button.internal == "OK" and newTitle and newTitle:match("%S") then
+    -- The callback signature should match what ISTextBox.onClick is passing
+    local function onDialogResult(target, button)
+        -- Only process OK button clicks
+        if button and button.internal == "OK" then
+            -- Get text from the entry field
+            local newTitle = target.entry:getText()
+
+            if newTitle and newTitle:match("%S") then
+                -- Update the window title
                 window:setTitle(newTitle)
                 window:bringToTop()
                 window:dirtyUI()
 
+                -- Save to modData if furniture exists
                 if TaskBoard_mainWindowFurniture then
                     local modData = TaskBoard_Core.fetchModData(TaskBoard_mainWindowFurniture)
                     modData.boardTitle = newTitle
                     TaskBoard_mainWindowFurniture:transmitModData()
                 end
             end
-        end,
-        nil
+        end
+    end
+
+    -- Create the ISTextBox (matches original signature exactly)
+    local textBox = ISTextBox:new(
+        getCore():getScreenWidth() / 2 - 150,   -- x
+        getCore():getScreenHeight() / 2 - 50,   -- y
+        300, 100,                               -- width, height
+        "Rename Board",                         -- text
+        window:getTitle(),                      -- defaultEntryText
+        nil,                                    -- target (we don't use this)
+        onDialogResult,                         -- onclick callback
+        nil                                     -- player
     )
     textBox:initialise()
     textBox:addToUIManager()
 end
 
 function TaskBoard_Title.patchWindowForRename(window)
+    -- Store original handlers
     local orig_onMouseDown = window.onMouseDown
     local orig_onMouseUp = window.onMouseUp
     local orig_onMouseMove = window.onMouseMove
 
+    -- Add tracking variables
     window.titleBarClicked = false
     window.wasDragged = false
 
+    -- Override mouse down to track title bar clicks
     window.onMouseDown = function(self, x, y)
         if y < self:titleBarHeight() then
             self.titleBarClicked = true
             self.wasDragged = false
         end
-        return orig_onMouseDown(self, x, y)
+        if orig_onMouseDown then orig_onMouseDown(self, x, y) end
     end
 
+    -- Override mouse move to track dragging
     window.onMouseMove = function(self, dx, dy)
         if self.titleBarClicked and (math.abs(dx) > 2 or math.abs(dy) > 2) then
             self.wasDragged = true
         end
-        return orig_onMouseMove(self, dx, dy)
+        if orig_onMouseMove then orig_onMouseMove(self, dx, dy) end
     end
 
+    -- Override mouse up to handle rename on click
     window.onMouseUp = function(self, x, y)
         if self.titleBarClicked and not self.wasDragged and y < self:titleBarHeight() then
             showRenameDialog(self)
         end
         self.titleBarClicked = false
-        return orig_onMouseUp(self, x, y)
+        if orig_onMouseUp then orig_onMouseUp(self, x, y) end
     end
 end
 

--- a/media/lua/client/TaskBoard_Title.lua
+++ b/media/lua/client/TaskBoard_Title.lua
@@ -1,0 +1,62 @@
+TaskBoard_Title = {}
+
+local function showRenameDialog(window)
+    local textBox = ISTextBox:new(
+        getCore():getScreenWidth() / 2 - 150,
+        getCore():getScreenHeight() / 2 - 50,
+        300, 100,
+        "Rename Board",
+        window:getTitle(),
+        nil,
+        function(button, newTitle)
+            if button and button.internal == "OK" and newTitle and newTitle:match("%S") then
+                window:setTitle(newTitle)
+                window:bringToTop()
+                window:dirtyUI()
+
+                if TaskBoard_mainWindowFurniture then
+                    local modData = TaskBoard_Core.fetchModData(TaskBoard_mainWindowFurniture)
+                    modData.boardTitle = newTitle
+                    TaskBoard_mainWindowFurniture:transmitModData()
+                end
+            end
+        end,
+        nil
+    )
+    textBox:initialise()
+    textBox:addToUIManager()
+end
+
+function TaskBoard_Title.patchWindowForRename(window)
+    local orig_onMouseDown = window.onMouseDown
+    local orig_onMouseUp = window.onMouseUp
+    local orig_onMouseMove = window.onMouseMove
+
+    window.titleBarClicked = false
+    window.wasDragged = false
+
+    window.onMouseDown = function(self, x, y)
+        if y < self:titleBarHeight() then
+            self.titleBarClicked = true
+            self.wasDragged = false
+        end
+        return orig_onMouseDown(self, x, y)
+    end
+
+    window.onMouseMove = function(self, dx, dy)
+        if self.titleBarClicked and (math.abs(dx) > 2 or math.abs(dy) > 2) then
+            self.wasDragged = true
+        end
+        return orig_onMouseMove(self, dx, dy)
+    end
+
+    window.onMouseUp = function(self, x, y)
+        if self.titleBarClicked and not self.wasDragged and y < self:titleBarHeight() then
+            showRenameDialog(self)
+        end
+        self.titleBarClicked = false
+        return orig_onMouseUp(self, x, y)
+    end
+end
+
+return TaskBoard_Title

--- a/media/lua/client/TaskBoard_Title.lua
+++ b/media/lua/client/TaskBoard_Title.lua
@@ -1,59 +1,42 @@
-require("ISUI/ISPanel")
-require("ISUI/ISButton")
-require("ISUI/ISTextBox")
-
 TaskBoard_Title = {}
 
 local function showRenameDialog(window)
-    -- The callback signature should match what ISTextBox.onClick is passing
-    local function onDialogResult(target, button)
-        -- Only process OK button clicks
+    local function onDialogResult(textBox, button)
         if button and button.internal == "OK" then
-            -- Get text from the entry field
-            local newTitle = target.entry:getText()
-
+            local newTitle = textBox.entry:getText()
             if newTitle and newTitle:match("%S") then
-                -- Update the window title
                 window:setTitle(newTitle)
-                window:bringToTop()
-                window:dirtyUI()
-
-                -- Save to modData if furniture exists
                 if TaskBoard_mainWindowFurniture then
-                    local modData = TaskBoard_Core.fetchModData(TaskBoard_mainWindowFurniture)
-                    modData.boardTitle = newTitle
+                    TaskBoard_Title.set(TaskBoard_mainWindowFurniture, newTitle)
                     TaskBoard_mainWindowFurniture:transmitModData()
+                    TaskBoard_Core.sendTaskCommand("TaskBoardTitleUpdated", TaskBoard_mainWindowFurniture, newTitle)
                 end
             end
         end
     end
 
-    -- Create the ISTextBox (matches original signature exactly)
     local textBox = ISTextBox:new(
-        getCore():getScreenWidth() / 2 - 150,   -- x
-        getCore():getScreenHeight() / 2 - 50,   -- y
-        300, 100,                               -- width, height
-        "Rename Board",                         -- text
-        window:getTitle(),                      -- defaultEntryText
-        nil,                                    -- target (we don't use this)
-        onDialogResult,                         -- onclick callback
-        nil                                     -- player
+        getCore():getScreenWidth() / 2 - 150,
+        getCore():getScreenHeight() / 2 - 50,
+        300, 100,
+        "Rename Board",
+        window:getTitle()
     )
+    textBox.onclick = onDialogResult
+    textBox.target = textBox
+
     textBox:initialise()
     textBox:addToUIManager()
 end
 
 function TaskBoard_Title.patchWindowForRename(window)
-    -- Store original handlers
     local orig_onMouseDown = window.onMouseDown
     local orig_onMouseUp = window.onMouseUp
     local orig_onMouseMove = window.onMouseMove
 
-    -- Add tracking variables
     window.titleBarClicked = false
     window.wasDragged = false
 
-    -- Override mouse down to track title bar clicks
     window.onMouseDown = function(self, x, y)
         if y < self:titleBarHeight() then
             self.titleBarClicked = true
@@ -62,7 +45,6 @@ function TaskBoard_Title.patchWindowForRename(window)
         if orig_onMouseDown then orig_onMouseDown(self, x, y) end
     end
 
-    -- Override mouse move to track dragging
     window.onMouseMove = function(self, dx, dy)
         if self.titleBarClicked and (math.abs(dx) > 2 or math.abs(dy) > 2) then
             self.wasDragged = true
@@ -70,7 +52,6 @@ function TaskBoard_Title.patchWindowForRename(window)
         if orig_onMouseMove then orig_onMouseMove(self, dx, dy) end
     end
 
-    -- Override mouse up to handle rename on click
     window.onMouseUp = function(self, x, y)
         if self.titleBarClicked and not self.wasDragged and y < self:titleBarHeight() then
             showRenameDialog(self)
@@ -78,6 +59,11 @@ function TaskBoard_Title.patchWindowForRename(window)
         self.titleBarClicked = false
         if orig_onMouseUp then orig_onMouseUp(self, x, y) end
     end
+end
+
+function TaskBoard_Title.set(furniture, newTitle)
+    local modData = TaskBoard_Core.fetchModData(furniture)
+    modData.boardTitle = newTitle
 end
 
 return TaskBoard_Title

--- a/media/lua/server/TaskBoard_Server.lua
+++ b/media/lua/server/TaskBoard_Server.lua
@@ -12,7 +12,17 @@ local commandHandlers = {
             y = args.y,
             z = args.z
         })
-    end
+    end,
+
+    TaskBoardTitleUpdated = function(player, args, taskBoard)
+        TaskBoard_Title.set(taskBoard, args.title)
+        sendServerCommand("TaskBoard", "TaskBoardTitleUpdated", {
+            x = args.x,
+            y = args.y,
+            z = args.z,
+            title = args.title
+        })
+    end,
 }
 
 local function onReceivePackets(module, command, player, args)

--- a/media/lua/shared/TaskBoard_Core.lua
+++ b/media/lua/shared/TaskBoard_Core.lua
@@ -117,17 +117,22 @@ function TaskBoard_Core.delete(furniture, task)
 end
 
 
-function TaskBoard_Core.sendTaskCommand(command, furniture, action, task)
+function TaskBoard_Core.sendTaskCommand(command, furniture, arg1, arg2)
     local square = furniture:getSquare()
     if not square then return end
 
     local data = {
         x = square:getX(),
         y = square:getY(),
-        z = square:getZ(),
-        action = action,
-        task = task
+        z = square:getZ()
     }
+
+    if command == "TaskBoardTaskUpdated" then
+        data.action = arg1
+        data.task = arg2
+    elseif command == "TaskBoardTitleUpdated" then
+        data.title = arg1
+    end
 
     if isClient() then
         sendClientCommand("TaskBoard", command, data)

--- a/media/lua/shared/TaskBoard_Core.lua
+++ b/media/lua/shared/TaskBoard_Core.lua
@@ -47,8 +47,12 @@ end
 local function reloadAllTablesInClient(furniture)
     if not furniture then return end
 
-    local tasks = TaskBoard_Core.fetchModData(furniture).tasks or {}
+    local modData = TaskBoard_Core.fetchModData(furniture)
 
+    local title = modData.boardTitle or "Unknown Task Board"
+    TaskBoard_mainWindow:setTitle(title)
+
+    local tasks = modData.tasks or {}
     local sectionMap = {
         [1] = {},
         [2] = {},

--- a/media/lua/shared/TaskBoard_Utils.lua
+++ b/media/lua/shared/TaskBoard_Utils.lua
@@ -69,6 +69,11 @@ end
 function TaskBoard_Utils.getFurnitureName(furniture)
     if not furniture then return "Unknown Furniture" end
 
+    local modData = TaskBoard_Core.fetchModData(furniture)
+    if modData and modData.boardTitle then
+        return modData.boardTitle
+    end
+
     local sprite = furniture:getSprite()
     if sprite then
         local translationKey = sprite:getProperties():Val("CustomName")


### PR DESCRIPTION
Fixes #33.

Click on the title bar to rename. Dragging the title bar will not trigger the rename and will instead use vanilla repositioning. Task Boards will have a default name format of: `<furniture name> Task Board`.

- [x] Implement default name. Store names in `furniture:modData.movableData`.
- [x] Sync the changes actively through clients the same way as tasks are actively synced.
- [x] Click title to rename.
- [x] The context menu should use the new name.